### PR TITLE
Check slack error response and fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Optional:
 - `CUSTOM_DOMAIN_NAME`: Custom domain name to be used to reach to Belldog instance. If omitted, host/authority HTTP field will be used.
 
 ### Slack permissions
+See `./example_app_manifest.yaml` to use Slack App Manifest.
+
 Posting messages:
 
 - `chat:write.public`: To post not-invited channels.
@@ -79,6 +81,8 @@ Optional:
 - `chat:write.customize`: Post message as other entities.
 
 ### Slack slash commands
+See `./example_app_manifest.yaml` to use Slack App Manifest.
+
 Endpoint is `<base_url>/slash/` (requires tail slash).
 
 - `/belldog-show`: "Show all tokens connected to this channel.", no hint

--- a/example_app_manifest.yaml
+++ b/example_app_manifest.yaml
@@ -1,0 +1,47 @@
+display_information:
+  name: Belldog
+  description: Manage and proxy Slack webhooks
+  background_color: "#7a5d41"
+features:
+  bot_user:
+    display_name: Belldog
+    always_online: true
+  slash_commands:
+    # TODO: Edit URLs
+    - command: /belldog-show
+      url: https://example.com/slash/
+      description: Show all tokens connected to this channel.
+      should_escape: false
+    - command: /belldog-generate
+      url: https://example.com/slash/
+      description: Generate token and webhook URL.
+      should_escape: false
+    - command: /belldog-regenerate
+      url: https://example.com/slash/
+      description: Regenerate another token and URL.
+      should_escape: false
+    - command: /belldog-revoke
+      url: https://example.com/slash/
+      description: Revoke token. Only available in the channel in which the token was
+        generated.
+      usage_hint: <token>
+      should_escape: false
+    - command: /belldog-revoke-renamed
+      url: https://example.com/slash/
+      description: Revoke old token. Use this after channel name renamed.
+      usage_hint: <old channel name> <token>
+      should_escape: false
+oauth_config:
+  scopes:
+    bot:
+      - channels:read
+      - chat:write
+      - chat:write.public
+      - commands
+      - groups:read
+      - groups:write
+      - chat:write.customize
+settings:
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false

--- a/proxy.go
+++ b/proxy.go
@@ -151,7 +151,7 @@ func handleWebhook(ctx context.Context, req request, body []byte) (response, err
 	}
 
 	kit := slack.NewKit(slackToken)
-	if err := kit.PostMessage(ctx, res.ChannelID, payload); err != nil {
+	if err := kit.PostMessage(ctx, res.ChannelID, res.ChannelName, payload); err != nil {
 		return response{}, fmt.Errorf("PostMessage failed: %w", err)
 	}
 


### PR DESCRIPTION
Belldog prevents generating new webhook URLs in private channels in which belldog is not invited. But in case a public channel converted to a private channel, existing webhook URL will not work because belldog is not invited to the private channel.

In that case, belldog doesn't fail or return errors due to not checking Slack PostMessage error response, but belldog should fail when Slack API returns errors. Then belldog operators can handle the situation by inviting belldog to the private channels.

Tested in sandbox env.

@s-tajima please drop a quick review.