### PR TITLE
Upgrade go version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /main
 /function.zip
+/belldog

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ COPY . ./
 # -ldflags to reduce binary size.
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags '-w -s' -o /usr/local/bin/app .
 
-FROM public.ecr.aws/lambda/go:1.2022.08.18.12
+FROM public.ecr.aws/lambda/provided:al2023
 COPY --from=build /usr/local/bin/app ${LAMBDA_TASK_ROOT}
 CMD ["app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.19 AS build
+FROM golang:1.21 AS build
 WORKDIR /src
 # pre-copy/cache go.mod for pre-downloading dependencies and only redownloading
 # them in subsequent builds if they change.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Finatext/belldog
 
-go 1.19
+go 1.21
 
 require (
 	github.com/aws/aws-lambda-go v1.34.1

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,10 @@ github.com/slack-go/slack v0.11.3/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQ
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Also, use OS-only base image due to Go base image deprecation. https://docs.aws.amazon.com/lambda/latest/dg/go-image.html#go-image-v1

In terms of OS-only base images, AWS currently provides al2023 and al2. al2023 (Amazon Linux 2023) seems newer than al2 (Amazon Linux 2), so we'll use it.

- https://gallery.ecr.aws/lambda/provided
- https://docs.aws.amazon.com/linux/al2023/ug/what-is-amazon-linux.html