### PR TITLE
[fix]decode when channelName is encoded

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -20,4 +20,11 @@ func TestPathRe(t *testing.T) {
 	if _, _, err := parsePath("/xxx/random/abc"); err == nil {
 		t.Error("case 4 failed")
 	}
+
+	t.Run("URL decode", func(t *testing.T) {
+		channelName, token, err := parsePath("/p/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF/xxxx")
+		if err != nil || channelName != "こんにちは" || token != "xxxx" {
+			t.Errorf("url encoded channel case failed: %s", err)
+		}
+	})
 }

--- a/proxy.go
+++ b/proxy.go
@@ -331,9 +331,14 @@ const correctMatchSize = 3
 var pathRe = regexp.MustCompilePOSIX(`^/p/([^/]+)/([^/]+)/?$`)
 
 func parsePath(path string) (channelName string, token string, err error) {
-	res := pathRe.FindStringSubmatch(path)
+	decodedPath, err := url.PathUnescape(path)
+	if err != nil {
+		err = fmt.Errorf("error decoding path `%s`: %v", path, err)
+		return
+	}
+	res := pathRe.FindStringSubmatch(decodedPath)
 	if len(res) != correctMatchSize {
-		err = fmt.Errorf("channelName or token not found: %s", path)
+		err = fmt.Errorf("channelName or token not found: %s", decodedPath)
 		return
 	}
 	channelName, token = res[1], res[2]

--- a/proxy.go
+++ b/proxy.go
@@ -333,7 +333,7 @@ var pathRe = regexp.MustCompilePOSIX(`^/p/([^/]+)/([^/]+)/?$`)
 func parsePath(path string) (channelName string, token string, err error) {
 	decodedPath, err := url.PathUnescape(path)
 	if err != nil {
-		err = fmt.Errorf("error decoding path `%s`: %v", path, err)
+		err = fmt.Errorf("error decoding path `%s`: %w", path, err)
 		return
 	}
 	res := pathRe.FindStringSubmatch(decodedPath)


### PR DESCRIPTION
## why
When the channel name is in Japanese, like "こんにちは", it gets parsed as a URL-encoded channel name, which results in a "Not Found" error.
Therefore, I added a decoding process.