### PR TITLE
Flush OTel metrics on every execution

### DIFF
--- a/cmd/lambda/lambda.go
+++ b/cmd/lambda/lambda.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/caarlos0/env/v11"
 	"github.com/cockroachdb/errors"
-	lambdadetector "go.opentelemetry.io/contrib/detectors/aws/lambda"
 
 	"github.com/Finatext/belldog/internal/appconfig"
 	"github.com/Finatext/belldog/internal/handler"
@@ -58,12 +57,7 @@ func doMain() error {
 
 	logLevel.Set(config.GoLog)
 
-	// Stripped down Lambda collector does not support resource detection, so inject them in application layer.
-	lambdaResource, err := lambdadetector.NewResourceDetector().Detect(ctx)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	flusher, cleanup, err := telemetry.SetupOTel(ctx, lambdaResource, &config)
+	flusher, cleanup, err := telemetry.SetupOTelLambda(ctx, config)
 	if err != nil {
 		return errors.Wrap(err, "failed to setup OpenTelemetry")
 	}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -50,8 +50,7 @@ func doMain() error {
 	}
 
 	logLevel.Set(config.GoLog)
-
-	_, cleanup, err := telemetry.SetupOTel(ctx, nil, &config)
+	cleanup, err := telemetry.SetupOTel(ctx, config)
 	if err != nil {
 		return errors.Wrap(err, "failed to setup OpenTelemetry")
 	}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -51,7 +51,7 @@ func doMain() error {
 
 	logLevel.Set(config.GoLog)
 
-	cleanup, err := telemetry.SetupOTel(ctx, nil, &config)
+	_, cleanup, err := telemetry.SetupOTel(ctx, nil, &config)
 	if err != nil {
 		return errors.Wrap(err, "failed to setup OpenTelemetry")
 	}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	lambdadetector "go.opentelemetry.io/contrib/detectors/aws/lambda"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	sdk "go.opentelemetry.io/otel/sdk/metric"
@@ -22,8 +23,25 @@ type Flusher func(ctx context.Context) error
 
 // SetupOTel initializes and setup global state for metrics collection.
 // If config.NoOTel is true, this will setup the No-Op.
-func SetupOTel(ctx context.Context, base *resource.Resource, config *appconfig.Config) (Flusher, func(), error) {
-	if config != nil && config.NoOTel {
+func SetupOTel(ctx context.Context, config appconfig.Config) (func(), error) {
+	// We don't need flusher in non-Lambda environments.
+	_, cleanup, err := setupOTelInner(ctx, nil, config)
+	return cleanup, err
+}
+
+// SetupOTelLambda initializes OTel resources and global state for metrics collection.
+func SetupOTelLambda(ctx context.Context, config appconfig.Config) (Flusher, func(), error) {
+	// Stripped down Lambda collector does not support resource detection, so inject them in application layer.
+	lambdaResource, err := lambdadetector.NewResourceDetector().Detect(ctx)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	return setupOTelInner(ctx, lambdaResource, config)
+}
+
+func setupOTelInner(ctx context.Context, base *resource.Resource, config appconfig.Config) (Flusher, func(), error) {
+	if config.NoOTel {
 		// If nothing is set to otel.Meter, the SDK will use the no-op implementation.
 		return func(ctx context.Context) error {
 			return nil


### PR DESCRIPTION
In Lambda environment, functions can be freeze. To avoid data delay of metrics, force flush on every invocation.