### PR TITLE
Don't run build-and-push job on every PR

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -41,7 +41,7 @@ jobs:
   #   - https://github.com/docker/metadata-action#semver
   build-and-push-image:
     timeout-minutes: 15
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'pull_request'
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pr-preview'))
     needs:
       - test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Previously, docker image build and push job was triggered on every PR but we only need it on a few specific PRs. Limit job execution with a label.